### PR TITLE
Fix warnings which arise when built against iOS 6 or later.

### DIFF
--- a/UIImage+Resize.m
+++ b/UIImage+Resize.m
@@ -94,7 +94,7 @@
             break;
             
         default:
-            [NSException raise:NSInvalidArgumentException format:@"Unsupported content mode: %d", contentMode];
+            [NSException raise:NSInvalidArgumentException format:@"Unsupported content mode: %ld", contentMode];
     }
     
     CGSize newSize = CGSizeMake(self.size.width * ratio, self.size.height * ratio);
@@ -126,7 +126,7 @@
                                                8,
                                                0,
                                                colorSpace,
-                                               kCGImageAlphaPremultipliedLast );
+                                               (CGBitmapInfo)kCGImageAlphaPremultipliedLast );
     CGColorSpaceRelease(colorSpace);
 	
     // Rotate and/or flip the image if required by its orientation


### PR DESCRIPTION
There are two small warnings when trying to use this library under Xcode 5 and iOS 7; this pull request clears them up.
